### PR TITLE
workaround fix for yarn3

### DIFF
--- a/node_modules/.bin/cli
+++ b/node_modules/.bin/cli
@@ -1,1 +1,0 @@
-../cli/bin/run

--- a/node_modules/cli
+++ b/node_modules/cli
@@ -1,1 +1,0 @@
-../packages/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,5 +66,8 @@
   "keywords": [
     "oclif"
   ],
-  "types": "dist/index.d.ts"
+  "types": "dist/index.d.ts",
+  "installConfig": {
+    "hoistingLimits": "workspaces"
+  }
 }


### PR DESCRIPTION
configuring install to limit hoisting to the workspace works around the issue